### PR TITLE
Update live URL in README to GitHub Pages default domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,6 @@ Controls:
 
 Slides to be shown before TAP briefings. Written using reveal.js.
 
-You can view the show at http://blog.operationcode.org/tap-deck/.
+You can view the show at http://operationcode.github.io/tap-deck/ 
 
 Inspired by [PDX Ruby Slide Deck](https://github.com/pdxruby/preshow).


### PR DESCRIPTION
- Updated the live URL in the README to the current one we are using for Project Pages with GitHub pages.  
- The "blog.operationcode.org" custom subdomain will no longer affect Project Pages, see https://github.com/OperationCode/blog-old/issues/3 .

:eyes: @jdspringr07 
